### PR TITLE
Fix issue with ZERO plural type for FR

### DIFF
--- a/src/middlewares/pluralise.js
+++ b/src/middlewares/pluralise.js
@@ -20,7 +20,7 @@ const pluralTypes = {
     return n < 2 ? n : 5
   },
   french: function(n) {
-    return n > 1 ? 5 : 1
+    return n < 2 ? n : 5
   },
   russian: function(n) {
     return n % 10 == 1 && n % 100 != 11


### PR DESCRIPTION
We have ZERO type in PA for France
But we can set this type (now we can set only ONE or MANY)
